### PR TITLE
Fixed issue where parallax functionality was broken in IE7 and IE8. This...

### DIFF
--- a/stellar.js
+++ b/stellar.js
@@ -5,7 +5,7 @@
  * markdalgleish.mit-license.org
  */
 ;(function($, window, document, undefined){
-	
+
 	var pluginName = 'stellar',
 		defaults = {
 			scrollProperty: 'scroll',
@@ -21,38 +21,38 @@
 			hideElement: function($elem) { $elem.hide(); },
 			showElement: function($elem) { $elem.show(); }
 		},
-		
+
 		scrollProperty = {
 			scroll: {
 				getTop: function($elem) { return $elem.scrollTop();	},
 				setTop: function($elem, val) { $elem.scrollTop(val); },
-				
+
 				getLeft: function($elem) { return $elem.scrollLeft(); },
 				setLeft: function($elem, val) { $elem.scrollLeft(val); }
 			},
 			position: {
 				getTop: function($elem) { return parseInt($elem.css('top'), 10) * -1; },
 				setTop: function($elem, val) { $elem.css('top', val); },
-				
+
 				getLeft: function($elem) { return parseInt($elem.css('left'), 10) * -1; },
 				setLeft: function($elem, val) { $elem.css('left', val); }
 			},
 			margin: {
 				getTop: function($elem) { return parseInt($elem.css('margin-top'), 10) * -1; },
 				setTop: function($elem, val) { $elem.css('margin-top', val); },
-				
+
 				getLeft: function($elem) { return parseInt($elem.css('margin-left'), 10) * -1; },
 				setLeft: function($elem, val) { $elem.css('margin-left', val); }
 			},
 			transform: {
 				getTop: function($elem) { return ($elem.css(vendorPrefix + 'transform') !== 'none' ? parseInt($elem.css(vendorPrefix + 'transform').match(/(-?[0-9]+)/g)[5], 10) * -1 : 0); },
 				setTop: function($elem, val) { setTransform($elem, val, 'Y'); },
-				
+
 				getLeft: function($elem) { return ($elem.css(vendorPrefix + 'transform') !== 'none' ? parseInt($elem.css(vendorPrefix + 'transform').match(/(-?[0-9]+)/g)[4], 10) * -1 : 0); },
 				setLeft: function($elem, val) {	setTransform($elem, val, 'X');	}
 			}
 		},
-		
+
 		positionProperty = {
 			position: {
 				setTop: function($elem, top) { $elem.css('top', top); },
@@ -63,10 +63,10 @@
 				setLeft: function($elem, left, startingLeft) { setTransform($elem, left - startingLeft, 'X'); }
 			}
 		},
-		
+
 		vendorPrefix = (function() {
 			var prefix = '';
-			
+
 			if ($.browser.webkit) {
 				prefix = '-webkit-';
 			} else if ($.browser.mozilla) {
@@ -76,20 +76,20 @@
 			} else if ($.browser.msie) {
 				prefix = '-ms-'
 			}
-			
+
 			return prefix;
 		})(),
-		
+
 		setTransform = function($elem, val, dimension /* 'X' or 'Y' */) {
 			var currentTransform = $elem.css(vendorPrefix + 'transform');
-			
+
 			if (currentTransform === 'none') {
 				$elem.css(vendorPrefix + 'transform', 'translate' + dimension + '(' + val + 'px)');
 			} else {
 				$elem.css(vendorPrefix + 'transform', replaceNthOccurence(currentTransform, /(-?[0-9]+[.]?[0-9]*)/g, (dimension === 'X' ? 5 : 6), val));
 			}
 		},
-		
+
 		replaceNthOccurence = function(original, pattern, n, replace) {
 			var parts,
 				tempParts,
@@ -114,24 +114,24 @@
 
 	function Plugin(element, options) {
 		this.element = element;
-		this.options = $.extend({}, defaults, options);		
- 
+		this.options = $.extend({}, defaults, options);
+
 		this._defaults = defaults;
 		this._name = pluginName;
-		
+
 		this.init();
 	}
 
 	Plugin.prototype = {
 		init: function() {
 			this.options.name = pluginName + '_' + Math.floor(Math.random()*10000);
-			
+
 			this._defineElements();
 			this._defineGetters();
 			this._defineSetters();
-			
+
 			this.refresh();
-			
+
 			this._startViewportDetectionLoop();
 			this._startAnimationLoop();
 		},
@@ -143,30 +143,30 @@
 		},
 		_defineGetters: function() {
 			var self = this;
-			
+
 			this._getScrollLeft = function() {
 				return scrollProperty[self.options.scrollProperty].getLeft(self.$scrollElement);
 			};
-			
+
 			this._getScrollTop = function() {
 				return scrollProperty[self.options.scrollProperty].getTop(self.$scrollElement);
 			};
 		},
 		_defineSetters: function() {
 			var self = this;
-			
+
 			this._setScrollLeft = function(val) {
 				scrollProperty[self.options.scrollProperty].setLeft(self.$scrollElement, val);
 			};
-			
+
 			this._setScrollTop = function(val) {
 				scrollProperty[self.options.scrollProperty].setTop(self.$scrollElement, val);
 			};
-			
+
 			this._setLeft = function($elem, left, startingLeft) {
 				positionProperty[self.options.positionProperty].setLeft($elem, left, startingLeft);
 			};
-			
+
 			this._setTop = function($elem, top, startingTop) {
 				positionProperty[self.options.positionProperty].setTop($elem, top, startingTop);
 			};
@@ -175,28 +175,28 @@
 			var self = this,
 				oldLeft = self._getScrollLeft(),
 				oldTop = self._getScrollTop();
-			
+
 			this._setScrollLeft(0);
 			this._setScrollTop(0);
-			
+
 			this._setOffsets();
 			this._findParticles();
 			this._findBackgrounds();
-			
+
 			// Fix for WebKit background rendering bug
 			if (navigator.userAgent.indexOf('WebKit') > 0) {
 				$(window).load(function(){
 					var oldLeft = self._getScrollLeft(),
 						oldTop = self._getScrollTop();
-			
+
 					self._setScrollLeft(oldLeft + 1);
 					self._setScrollTop(oldTop + 1);
-			
+
 					self._setScrollLeft(oldLeft);
 					self._setScrollTop(oldTop);
 				});
 			}
-			
+
 			self._setScrollLeft(oldLeft);
 			self._setScrollTop(oldTop);
 		},
@@ -204,17 +204,17 @@
 			var self = this,
 				scrollLeft = this._getScrollLeft(),
 				scrollTop = this._getScrollTop();
-			
+
 			if (this.particles !== undefined) {
 				for (var i = this.particles.length - 1; i >= 0; i--) {
 					this.particles[i].$element.data('stellar-elementIsActive', undefined);
 				}
 			}
-			
+
 			this.particles = [];
-			
+
 			if (!this.options.parallaxElements) return;
-			
+
 			this.$element.find('[data-stellar-ratio]').each(function(i){
 				var $this = $(this),
 					horizontalOffset,
@@ -228,16 +228,16 @@
 					parentOffsetTop = 0,
 					tempParentOffsetLeft = 0,
 					tempParentOffsetTop = 0;
-				
+
 				// Ensure this element isn't already part of another scrolling element
 				if (!$this.data('stellar-elementIsActive')) {
 					$this.data('stellar-elementIsActive', this);
 				} else if ($this.data('stellar-elementIsActive') !== this) {
 					return;
 				}
-				
+
 				self.options.showElement($this);
-				
+
 				// Save/restore the original top and left CSS values in case we refresh the particles or destroy the instance
 				if (!$this.data('stellar-startingLeft')) {
 					$this.data('stellar-startingLeft', $this.css('left'));
@@ -246,22 +246,42 @@
 					$this.css('left', $this.data('stellar-startingLeft'));
 					$this.css('top', $this.data('stellar-startingTop'));
 				}
-				
+
 				positionLeft = $this.position().left;
 				positionTop = $this.position().top;
-				
-				offsetLeft = $this.offset().left - parseInt($this.css('margin-left'), 10);
-				offsetTop = $this.offset().top - parseInt($this.css('margin-top'), 10);
-				
+
+				// Catch-all for margin left properties (this evaluates to 'auto' in IE7 and IE8)
+				if($this.css('margin-left') == "auto")
+				{
+					marginLeft = parseInt("0px", 10);
+				}
+				else
+				{
+					marginLeft = parseInt($this.css('margin-left'), 10);
+				}
+
+				// Catch-all for margin top properties (this evaluates to 'auto' in IE7 and IE8)
+				if($this.css('margin-top') == "auto")
+				{
+					marginTop = parseInt("0px", 10);
+				}
+				else
+				{
+					marginTop = parseInt($this.css('margin-top'), 10);
+				}
+
+				offsetLeft = $this.offset().left - marginLeft;
+				offsetTop = $this.offset().top - marginTop;
+
 				// Calculate the offset parent
 				$this.parents().each(function(){
 					var $this = $(this);
-					
+
 					if ($this.data('stellar-offset-parent') === true) {
 						parentOffsetLeft = tempParentOffsetLeft;
 						parentOffsetTop = tempParentOffsetTop;
 						$offsetParent = $this;
-						
+
 						return false;
 					} else {
 						tempParentOffsetLeft += $this.position().left;
@@ -272,8 +292,8 @@
 				// Detect the offsets
 				horizontalOffset = ($this.data('stellar-horizontal-offset') !== undefined ? $this.data('stellar-horizontal-offset') : ($offsetParent !== undefined && $offsetParent.data('stellar-horizontal-offset') !== undefined ? $offsetParent.data('stellar-horizontal-offset') : self.horizontalOffset));
 				verticalOffset = ($this.data('stellar-vertical-offset') !== undefined ? $this.data('stellar-vertical-offset') : ($offsetParent !== undefined && $offsetParent.data('stellar-vertical-offset') !== undefined ? $offsetParent.data('stellar-vertical-offset') : self.verticalOffset));
-				
-				//Add our object to the particles collection	
+
+				//Add our object to the particles collection
 				self.particles.push({
 					$element: $this,
 					$offsetParent: $offsetParent,
@@ -298,17 +318,17 @@
 				scrollLeft = this._getScrollLeft(),
 				scrollTop = this._getScrollTop(),
 				$backgroundElements;
-			
+
 			this.backgrounds = [];
-			
+
 			if (!this.options.parallaxBackgrounds) return;
-			
+
 			$backgroundElements = this.$element.find('[data-stellar-background-ratio]');
-			
+
 			if (this.$element.is('[data-stellar-background-ratio]')) {
 				$backgroundElements.add(this.$element);
 			}
-			
+
 			$backgroundElements.each(function(){
 				var $this = $(this),
 					backgroundPosition = $this.css('background-position').split(' '),
@@ -318,14 +338,14 @@
 					positionTop,
 					offsetLeft,
 					offsetTop;
-				
+
 				// Ensure this element isn't already part of another scrolling element
 				if (!$this.data('stellar-backgroundIsActive')) {
 					$this.data('stellar-backgroundIsActive', this);
 				} else if ($this.data('stellar-backgroundIsActive') !== this) {
 					return;
 				}
-				
+
 				// Save/restore the original top and left CSS values in case we destroy the instance
 				if (!$this.data('stellar-backgroundStartingLeft')) {
 					$this.data('stellar-backgroundStartingLeft', backgroundPosition[0]);
@@ -333,14 +353,34 @@
 				} else {
 					$this.css('background-position', $this.data('stellar-backgroundStartingLeft') + ' ' + $this.data('stellar-backgroundStartingTop'));
 				}
-				
-				offsetLeft = $this.offset().left - parseInt($this.css('margin-left'), 10) - scrollLeft;
-				offsetTop = $this.offset().top - parseInt($this.css('margin-top'), 10) - scrollTop;
-				
+
+				// Catch-all for margin left properties (this evaluates to 'auto' in IE7 and IE8)
+				if($this.css('margin-left') == "auto")
+				{
+					marginLeft = parseInt("0px", 10);
+				}
+				else
+				{
+					marginLeft = parseInt($this.css('margin-left'), 10);
+				}
+
+				// Catch-all for margin top properties (this evaluates to 'auto' in IE7 and IE8)
+				if($this.css('margin-top') == "auto")
+				{
+					marginTop = parseInt("0px", 10);
+				}
+				else
+				{
+					marginTop = parseInt($this.css('margin-top'), 10);
+				}
+
+				offsetLeft = $this.offset().left - marginLeft - scrollLeft;
+				offsetTop = $this.offset().top - marginTop - scrollTop;
+
 				// Detect the offsets
 				horizontalOffset = ($this.data('stellar-horizontal-offset') !== undefined ? $this.data('stellar-horizontal-offset') : self.horizontalOffset);
 				verticalOffset = ($this.data('stellar-vertical-offset') !== undefined ? $this.data('stellar-vertical-offset') : self.verticalOffset);
-				
+
 				self.backgrounds.push({
 					$element: $this,
 					isFixed: $this.css('background-attachment') === 'fixed',
@@ -387,9 +427,9 @@
 		},
 		_setOffsets: function() {
 			var self = this;
-			
+
 			$(window).unbind('resize.horizontal-' + this.name).unbind('resize.vertical-' + this.name);
-			
+
 			if (typeof this.options.horizontalOffset === 'function') {
 				this.horizontalOffset = this.options.horizontalOffset();
 				$(window).bind('resize.horizontal-' + this.name, function() {
@@ -398,7 +438,7 @@
 			} else {
 				this.horizontalOffset = this.options.horizontalOffset;
 			}
-			
+
 			if (typeof this.options.verticalOffset === 'function') {
 				this.verticalOffset = this.options.verticalOffset();
 				$(window).bind('resize.vertical-' + this.name, function() {
@@ -424,7 +464,7 @@
 				newPositionTop,
 				newOffsetLeft,
 				newOffsetTop;
-			
+
 			//First check that the scroll position or container size has changed
 			if (this.currentScrollLeft === scrollLeft && this.currentScrollTop === scrollTop && this.currentWidth === this.viewportWidth && this.currentHeight === this.viewportHeight) {
 				return;
@@ -434,39 +474,39 @@
 				this.currentWidth = this.viewportWidth;
 				this.currentHeight = this.viewportHeight;
 			}
-			
+
 			//Reposition elements
 			for (var i = this.particles.length - 1; i >= 0; i--) {
 				particle = this.particles[i];
-				
+
 				fixedRatioOffset = particle.isFixed ? 1 : 0;
-				
+
 				//Calculate position, then calculate what the particle's new offset will be (for visibility check)
 				if (this.options.horizontalScrolling) {
 					newPositionLeft = (scrollLeft + particle.horizontalOffset + this.viewportOffsetLeft + particle.startingPositionLeft - particle.startingOffsetLeft + particle.parentOffsetLeft) * -(particle.stellarRatio + fixedRatioOffset - 1) + particle.startingPositionLeft;
 					newOffsetLeft = newPositionLeft - particle.startingPositionLeft + particle.startingOffsetLeft;
-				}				
+				}
 				if (this.options.verticalScrolling) {
 					newPositionTop = (scrollTop + particle.verticalOffset + this.viewportOffsetTop + particle.startingPositionTop - particle.startingOffsetTop + particle.parentOffsetTop) * -(particle.stellarRatio + fixedRatioOffset - 1) + particle.startingPositionTop;
 					newOffsetTop = newPositionTop - particle.startingPositionTop + particle.startingOffsetTop;
-				}				
-				
+				}
+
 				//Check visibility
 				if (this.options.hideDistantElements) {
 					isVisibleHorizontal = !this.options.horizontalScrolling || newOffsetLeft + particle.width > (particle.isFixed ? 0 : scrollLeft) && newOffsetLeft < (particle.isFixed ? 0 : scrollLeft) + this.viewportWidth + this.viewportOffsetLeft;
 					isVisibleVertical = !this.options.verticalScrolling || newOffsetTop + particle.height > (particle.isFixed ? 0 : scrollTop) && newOffsetTop < (particle.isFixed ? 0 : scrollTop) + this.viewportHeight + this.viewportOffsetTop;
 				}
-				
+
 				if (isVisibleHorizontal && isVisibleVertical) {
 					if (particle.isHidden) {
 						this.options.showElement(particle.$element);
 						particle.isHidden = false;
 					}
-					
+
 					if (this.options.horizontalScrolling) {
 						this._setLeft(particle.$element, newPositionLeft, particle.startingPositionLeft);
 					}
-					
+
 					if (this.options.verticalScrolling) {
 						this._setTop(particle.$element, newPositionTop, particle.startingPositionTop);
 					}
@@ -477,15 +517,15 @@
 					}
 				}
 			}
-			
+
 			//Reposition backgrounds
 			for (var i = this.backgrounds.length - 1; i >= 0; i--) {
 				background = this.backgrounds[i];
-				
+
 				fixedRatioOffset = background.isFixed ? 0 : 1;
 				bgLeft = this.options.horizontalScrolling ? (scrollLeft - background.horizontalOffset - this.viewportOffsetLeft - background.startingOffsetLeft - background.startingBackgroundPositionLeft) * (fixedRatioOffset - background.stellarRatio) + 'px' : background.startingValueLeft;
 				bgTop = this.options.verticalScrolling ? (scrollTop - background.verticalOffset - this.viewportOffsetTop - background.startingOffsetTop - background.startingBackgroundPositionTop) * (fixedRatioOffset - background.stellarRatio) + 'px' : background.startingValueTop;
-				
+
 				background.$element.css('background-position', bgLeft + ' ' + bgTop);
 			}
 		},
@@ -493,30 +533,30 @@
 			var self = this,
 				detect = function() {
 					var viewportOffsets = self.$viewportElement.offset();
-					
+
 					self.viewportWidth = self.$viewportElement.width();
 					self.viewportHeight = self.$viewportElement.height();
-						
+
 			   		self.viewportOffsetTop = viewportOffsets !== null ? viewportOffsets.top : 0;
 			   		self.viewportOffsetLeft = viewportOffsets !== null ? viewportOffsets.left : 0;
 				};
-			
+
 			detect();
 			this._viewportDetectionInterval = setInterval(detect, this.options.viewportDetectionInterval);
 		},
 		_startAnimationLoop: function() {
 			var self = this,
 				requestAnimFrame = (function(){
-					return window.requestAnimationFrame    || 
-						window.webkitRequestAnimationFrame || 
-						window.mozRequestAnimationFrame    || 
-						window.oRequestAnimationFrame      || 
-						window.msRequestAnimationFrame     || 
+					return window.requestAnimationFrame    ||
+						window.webkitRequestAnimationFrame ||
+						window.mozRequestAnimationFrame    ||
+						window.oRequestAnimationFrame      ||
+						window.msRequestAnimationFrame     ||
 						function(callback, element){
 							window.setTimeout(callback, 1000 / 60);
 						};
 				})();
-			
+
 			this._animationLoop = function(){
 				requestAnimFrame(self._animationLoop);
 				self._repositionElements();
@@ -545,16 +585,16 @@
 			});
 		}
 	};
-	
+
 	$[pluginName] = function(options) {
 		var $window = $(window);
 		return $window.stellar.apply($window, Array.prototype.slice.call(arguments, 0));
 	};
-	
+
 	//Expose the scroll and position property function hashes so they can be extended
 	$[pluginName].scrollProperty = scrollProperty;
 	$[pluginName].positionProperty = positionProperty;
-	
+
 	//Expose the plugin class so it can be modified
 	window.Stellar = Plugin;
 })(jQuery, window, document);


### PR DESCRIPTION
... occurred when parallaxing elements were not given a left margin, which non-standards compliant browsers read as "auto" instead of "0px". This value would then be fed into parseInt. parseInt("0px") returns 0, whereas parseInt("auto") returns NaN.
