### PR TITLE
Fixed bug in _findBackgrounds() which caused to ignore elements with dat...

### DIFF
--- a/src/jquery.stellar.js
+++ b/src/jquery.stellar.js
@@ -357,8 +357,8 @@
 
 			$backgroundElements = this.$element.find('[data-stellar-background-ratio]');
 
-			if (this.$element.is('[data-stellar-background-ratio]')) {
-				$backgroundElements.add(this.$element);
+			if (this.$element.data('stellar-background-ratio')) {
+                $backgroundElements = $backgroundElements.add(this.$element);
 			}
 
 			$backgroundElements.each(function() {


### PR DESCRIPTION
...a-stellar-background if you pass them directly to stellar() function. Also replaced check for data property via "is([data-prop])" with "data('prop')".

1) $stuff.add() doesn't change $stuff, so $backgroundElements remains unchanged
http://api.jquery.com/add/ 

2) I think check with "data('something')" is more appropriate than "is([data-something])"

Thank you for such a nice library! :+1: 
