### PR TITLE
IE8 and IE10 scrollProperty transform bug fixes

### DIFF
--- a/src/jquery.stellar.js
+++ b/src/jquery.stellar.js
@@ -36,7 +36,7 @@
 				getLeft: function($elem) {
 					var computedTransform, matrix, left;
 					computedTransform = getComputedStyle($elem[0])[prefixedTransform];
-					if (computedTransform === 'none') {
+					if (typeof(computedTransform) === 'undefined' || computedTransform === 'none') {
 						left = 0;
 					} else {
 						matrix = computedTransform.replace(/[^0-9\-.,]/g, '').split(',');
@@ -47,14 +47,13 @@
 				getTop: function($elem) {
 					var computedTransform, matrix, top;
 					computedTransform = getComputedStyle($elem[0])[prefixedTransform];
-					if (computedTransform === 'none') {
+					if (typeof(computedTransform) === 'undefined' || computedTransform === 'none') {
 						top = 0;
 					} else {
 						matrix = computedTransform.replace(/[^0-9\-.,]/g, '').split(',');
 						top = parseInt(matrix[13] || matrix[5], 10) * -1;
 					}
 					return top;
-
 				}
 			}
 		},


### PR DESCRIPTION
I ran across some bugs in IE when using scrollProperty transform. These fixes are working for me and I thought you might want to incorporate them,

The matrix3d fix is based on this iscroll commit: https://github.com/cubiq/iscroll/commit/d31d6e6ff798a8adc572879549ac1a3e2f47a01e
