### PR TITLE
Replaced deprecated .load alias with .on() listener

### DIFF
--- a/src/jquery.stellar.js
+++ b/src/jquery.stellar.js
@@ -225,7 +225,7 @@
 
 			// Fix for WebKit background rendering bug
 			if (options && options.firstLoad && /WebKit/.test(navigator.userAgent)) {
-				$(window).load(function() {
+				$(window).on('load', function() {
 					var oldLeft = self._getScrollLeft(),
 						oldTop = self._getScrollTop();
 


### PR DESCRIPTION
This causes error in the console and prevents the plugin from running with new jQuery versions.

Please merge if the solution seems fit.